### PR TITLE
test: fix assertion enum variant

### DIFF
--- a/src/window/search.rs
+++ b/src/window/search.rs
@@ -50,7 +50,7 @@ mod tests {
         use WindowSearchAttribute::*;
 
         let params_and_expected = [
-            ("initial_title=^hello$", Title),
+            ("initial_title=^hello$", InitialTitle),
             ("title=^hello$", Title),
             ("initial_class=^hello$", InitialClass),
             ("class=^hello$", Class),


### PR DESCRIPTION
Resolves #26

A typo in the test assertion was causing the test not to pass. My bad!